### PR TITLE
[TVMScript] Set default global_symbol of T.prim_func

### DIFF
--- a/python/tvm/script/parser/tir/entry.py
+++ b/python/tvm/script/parser/tir/entry.py
@@ -44,6 +44,7 @@ def prim_func(func: Callable) -> Union[PrimFunc, Callable]:
         return func
     f = parse(func, utils.inspect_function_capture(func))
     setattr(f, "__name__", func.__name__)
+    f = f.with_attr("global_symbol", func.__name__)
     return f
 
 


### PR DESCRIPTION
set the default global_symbol at the stage of @T.prim_func, 
so that user no need to add it manually.